### PR TITLE
Pre-compile RegExp outside of hot loop, for speed

### DIFF
--- a/src/logic/generateGrid.js
+++ b/src/logic/generateGrid.js
@@ -12,7 +12,8 @@ function removeWordThatMatches(pattern, wordList) {
   // Given a patten and a list of words, finds a word that matches the pattern
   // and returns the word and the list with the word deleted
   // If no match was found, returns undefined and the unchanged wordlist
-  const wordIndex = wordList.findIndex((word) => word.match(`^${pattern}$`));
+  const patternRegExp = new RegExp(`^${pattern}$`);
+  const wordIndex = wordList.findIndex((word) => patternRegExp.exec(word));
 
   if (wordIndex > -1) {
     const word = wordList[wordIndex];


### PR DESCRIPTION
If I slide the "Number of pieces" slider all the way to the "+" end, generating a new puzzle is sometimes instant, but sometimes takes a second or so. On my phone it can be up to 15 seconds.

This change makes crossword generation about 2.5x faster on my laptop.