### PR TITLE
Make letters overlap to eliminate double border

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -310,11 +310,12 @@ a {
   grid-area: board;
   display: grid;
   touch-action: none;
-  justify-content: center;
+  justify-content: start;
+  align-content: start;
   grid-template-columns: repeat(12, var(--box-size));
   grid-template-rows: repeat(12, var(--box-size));
-  width: fit-content;
-  height: fit-content;
+  width: calc(12 * var(--box-size) + 1px);
+  height: calc(12 * var(--box-size) + 1px);
   justify-self: center;
   color: var(--light-color);
   border: 1px solid var(--light-color);

--- a/src/App.css
+++ b/src/App.css
@@ -322,6 +322,10 @@ a {
 }
 
 .letter {
+  box-sizing: border-box;
+  width: calc(var(--box-size) + 1px);
+  height: calc(var(--box-size) + 1px);
+
   display: flex;
   pointer-events: auto;
   touch-action: none;
@@ -418,6 +422,22 @@ a {
 
 .shadow-square {
   background-color: var(--shadow-color);
+  box-sizing: border-box;
+  position: relative;
+  left: 0;
+  top: 0;
+  width: calc(var(--box-size) + 1px);
+  height: calc(var(--box-size) + 1px);
+}
+
+.shadow-square.shadow-to-left {
+  left: 1px;
+  width: var(--box-size);
+}
+
+.shadow-square.shadow-to-top {
+  top: 1px;
+  height: var(--box-size);
 }
 
 .rules {

--- a/src/App.css
+++ b/src/App.css
@@ -3,7 +3,7 @@ html {
   --box-size: min(8vw, 5.5vh);
   --default-font-size: calc(var(--box-size) * 0.9);
   --dark-color: rgb(55 54 71);
-  --shadow-color: rgba(20 19 25 / 50%);
+  --shadow-color: rgb(20 19 25);
   --drag-color: rgba(77 76 99);
   --light-color: rgb(239 239 239);
 
@@ -421,15 +421,15 @@ a {
   text-align: center;
 }
 
+.drag-shadow {
+  opacity: 0.5;
+}
+
 .shadow-square {
   background-color: var(--shadow-color);
   box-sizing: border-box;
-  width: var(--box-size);
-  height: var(--box-size);
-  /* make shadows fall on the right and bottom borders, rather than top and left */
-  position: relative;
-  left: 1px;
-  top: 1px;
+  width: calc(var(--box-size) + 1px);
+  height: calc(var(--box-size) + 1px);
 }
 
 .rules {

--- a/src/App.css
+++ b/src/App.css
@@ -424,21 +424,12 @@ a {
 .shadow-square {
   background-color: var(--shadow-color);
   box-sizing: border-box;
-  position: relative;
-  left: 0;
-  top: 0;
-  width: calc(var(--box-size) + 1px);
-  height: calc(var(--box-size) + 1px);
-}
-
-.shadow-square.shadow-to-left {
-  left: 1px;
   width: var(--box-size);
-}
-
-.shadow-square.shadow-to-top {
-  top: 1px;
   height: var(--box-size);
+  /* make shadows fall on the right and bottom borders, rather than top and left */
+  position: relative;
+  left: 1px;
+  top: 1px;
 }
 
 .rules {

--- a/src/App.css
+++ b/src/App.css
@@ -347,6 +347,12 @@ a {
   color: rgb(226 88 88);
 }
 
+.letter-border {
+  box-sizing: border-box;
+  width: calc(var(--box-size) + 1px);
+  height: calc(var(--box-size) + 1px);
+}
+
 .borderTop {
   border-top: 1px solid var(--light-color);
 }
@@ -410,6 +416,10 @@ a {
 
 #drag-group .letter {
   background-color: var(--drag-color);
+}
+
+#drag-group .letter,
+#drag-group .letter-border {
   --lift: calc(var(--box-size) * -0.08);
   transform: translate(var(--lift), var(--lift));
 }

--- a/src/components/Board.js
+++ b/src/components/Board.js
@@ -106,8 +106,10 @@ export function dragDestinationOnBoard(gameState, pointer) {
     const maxTop = gameState.gridSize - groupHeight;
     const maxLeft = gameState.gridSize - groupWidth;
 
-    const squareWidth = boardRect.width / gameState.gridSize;
-    const squareHeight = boardRect.height / gameState.gridSize;
+    // Subtract 1 before dividing because the board is 12 squares wide, but has 13 1px borders.
+    // (It's admittedly silly to care about this, since the impact is only 1/12 of a pixel!)
+    const squareWidth = (boardRect.width - 1) / gameState.gridSize;
+    const squareHeight = (boardRect.height - 1) / gameState.gridSize;
     const pointerOffset = gameState.dragState.pointerOffset;
     const unclampedLeft = Math.round(
       (pointer.x - pointerOffset.x - boardRect.left) / squareWidth

--- a/src/components/Board.js
+++ b/src/components/Board.js
@@ -106,8 +106,8 @@ export function dragDestinationOnBoard(gameState, pointer) {
     const maxTop = gameState.gridSize - groupHeight;
     const maxLeft = gameState.gridSize - groupWidth;
 
-    // Subtract 1 before dividing because the board is 12 squares wide, but has 13 1px borders.
-    // (It's admittedly silly to care about this, since the impact is only 1/12 of a pixel!)
+    // Subtract 1 before dividing because the board is n squares wide, but has n+1 1px borders.
+    // (It's admittedly silly to care about this, since the impact is only 1/n of a pixel!)
     const squareWidth = (boardRect.width - 1) / gameState.gridSize;
     const squareHeight = (boardRect.height - 1) / gameState.gridSize;
     const pointerOffset = gameState.dragState.pointerOffset;

--- a/src/components/Board.js
+++ b/src/components/Board.js
@@ -49,8 +49,8 @@ export default function Board({
     />
   ));
 
-    // Any pieces that are currently being dragged over the board will render on the board as a single drag shadow
-    let dragShadow;
+  // Any pieces that are currently being dragged over the board will render on the board as a single drag shadow
+  let dragShadow;
   if (dragDestination?.where === "board") {
     const draggedPieces = pieces.filter((piece) =>
       dragPieceIDs.includes(piece.id)

--- a/src/components/DragGroup.js
+++ b/src/components/DragGroup.js
@@ -60,7 +60,12 @@ export default function DragGroup({ dispatchGameState, gameState }) {
         clearTimeout(timerID);
       }
     };
-  }, [isShifting, dragState.destination.where, dragState.dragHasMoved, dispatchGameState]);
+  }, [
+    isShifting,
+    dragState.destination.where,
+    dragState.dragHasMoved,
+    dispatchGameState,
+  ]);
 
   // Compute location.
   let top = dragState.pointer.y - dragState.pointerOffset.y;

--- a/src/components/DragShadow.js
+++ b/src/components/DragShadow.js
@@ -1,9 +1,16 @@
 import React from "react";
 
-function DragShadowSquare({ rowIndex, colIndex }) {
+function DragShadowSquare({ rowIndex, colIndex, hasShadowToTop, hasShadowToLeft }) {
+  let className = "shadow-square";
+  if (hasShadowToTop) {
+    className += " shadow-to-top";
+  }
+  if (hasShadowToLeft) {
+    className += " shadow-to-left";
+  }
   return (
     <div
-      className="shadow-square"
+      className={className}
       style={{
         gridRow: rowIndex + 1, // CSS grid coordinates are 1-based
         gridColumn: colIndex + 1,
@@ -22,6 +29,8 @@ export default function DragShadow({ grid, top, left }) {
             key={`${rowIndex}-${colIndex}`}
             rowIndex={rowIndex}
             colIndex={colIndex}
+            hasShadowToTop={rowIndex > 0 && grid[rowIndex - 1][colIndex] > 0}
+            hasShadowToLeft={colIndex > 0 && grid[rowIndex][colIndex - 1] > 0}
           />
         );
       }

--- a/src/components/DragShadow.js
+++ b/src/components/DragShadow.js
@@ -39,7 +39,7 @@ export default function DragShadow({ grid, top, left }) {
   }
 
   return (
-    <div className="piece shadow-piece" style={styles}>
+    <div className="piece drag-shadow" style={styles}>
       {squares}
     </div>
   );

--- a/src/components/DragShadow.js
+++ b/src/components/DragShadow.js
@@ -1,16 +1,9 @@
 import React from "react";
 
-function DragShadowSquare({ rowIndex, colIndex, hasShadowToTop, hasShadowToLeft }) {
-  let className = "shadow-square";
-  if (hasShadowToTop) {
-    className += " shadow-to-top";
-  }
-  if (hasShadowToLeft) {
-    className += " shadow-to-left";
-  }
+function DragShadowSquare({ rowIndex, colIndex }) {
   return (
     <div
-      className={className}
+      className="shadow-square"
       style={{
         gridRow: rowIndex + 1, // CSS grid coordinates are 1-based
         gridColumn: colIndex + 1,
@@ -29,8 +22,6 @@ export default function DragShadow({ grid, top, left }) {
             key={`${rowIndex}-${colIndex}`}
             rowIndex={rowIndex}
             colIndex={colIndex}
-            hasShadowToTop={rowIndex > 0 && grid[rowIndex - 1][colIndex] > 0}
-            hasShadowToLeft={colIndex > 0 && grid[rowIndex][colIndex - 1] > 0}
           />
         );
       }

--- a/src/components/Piece.js
+++ b/src/components/Piece.js
@@ -5,7 +5,6 @@ function Letter({
   letter,
   pieceRowIndex,
   pieceColIndex,
-  border,
   overlapping,
   gameIsSolved,
   dispatchGameState,
@@ -32,18 +31,6 @@ function Letter({
   if (gameIsSolved) {
     className += " filled";
   }
-  if (border.top) {
-    className += " borderTop";
-  }
-  if (border.bottom) {
-    className += " borderBottom";
-  }
-  if (border.left) {
-    className += " borderLeft";
-  }
-  if (border.right) {
-    className += " borderRight";
-  }
   if (overlapping) {
     className += " overlapping";
   }
@@ -65,6 +52,28 @@ function Letter({
   );
 }
 
+function LetterBorder({rowIndex, colIndex, border}) {
+  let className = "letter-border";
+  if (border.top) {
+    className += " borderTop";
+  }
+  if (border.bottom) {
+    className += " borderBottom";
+  }
+  if (border.left) {
+    className += " borderLeft";
+  }
+  if (border.right) {
+    className += " borderRight";
+  }
+  return <div
+    className={className}
+      style={{
+        gridRow: rowIndex + 1, // CSS grid coordinates are 1-based
+        gridColumn: colIndex + 1,
+      }} />;
+}
+
 export default function Piece({
   piece,
   where,
@@ -76,6 +85,7 @@ export default function Piece({
   const isDragging = where == "drag";
   const letters = piece.letters;
   let letterElements = [];
+  let borderElements = [];
   for (let rowIndex = 0; rowIndex < letters.length; rowIndex++) {
     for (let colIndex = 0; colIndex < letters[rowIndex].length; colIndex++) {
       const letter = letters[rowIndex][colIndex];
@@ -87,12 +97,6 @@ export default function Piece({
             letter={letter}
             pieceRowIndex={rowIndex}
             pieceColIndex={colIndex}
-            border={{
-              top: !letters[rowIndex - 1]?.[colIndex],
-              bottom: !letters[rowIndex + 1]?.[colIndex],
-              left: !letters[rowIndex][colIndex - 1],
-              right: !letters[rowIndex][colIndex + 1],
-            }}
             overlapping={
               isOnBoard &&
               overlapGrid[piece.boardTop + rowIndex][
@@ -101,6 +105,19 @@ export default function Piece({
             }
             gameIsSolved={gameIsSolved}
             dispatchGameState={dispatchGameState}
+          />
+        );
+        borderElements.push(
+          <LetterBorder
+            key={`border-${piece.id}-${rowIndex}-${colIndex}`}
+            rowIndex={rowIndex}
+            colIndex={colIndex}
+            border={{
+              top: !letters[rowIndex - 1]?.[colIndex],
+              bottom: !letters[rowIndex + 1]?.[colIndex],
+              left: !letters[rowIndex][colIndex - 1],
+              right: !letters[rowIndex][colIndex + 1],
+            }}
           />
         );
       }
@@ -129,6 +146,7 @@ export default function Piece({
       }}
     >
       {letterElements}
+      {borderElements}
     </div>
   );
 }

--- a/src/components/Piece.js
+++ b/src/components/Piece.js
@@ -52,7 +52,7 @@ function Letter({
   );
 }
 
-function LetterBorder({rowIndex, colIndex, border}) {
+function LetterBorder({ rowIndex, colIndex, border }) {
   let className = "letter-border";
   if (border.top) {
     className += " borderTop";
@@ -66,12 +66,15 @@ function LetterBorder({rowIndex, colIndex, border}) {
   if (border.right) {
     className += " borderRight";
   }
-  return <div
-    className={className}
+  return (
+    <div
+      className={className}
       style={{
         gridRow: rowIndex + 1, // CSS grid coordinates are 1-based
         gridColumn: colIndex + 1,
-      }} />;
+      }}
+    />
+  );
 }
 
 export default function Piece({


### PR DESCRIPTION
Each piece has a 1px border. So currently, when you place two pieces adjacent, you get a 2px border between them.

<img width="134" alt="Two pieces set corner-to-corner; the borders don't line up." src="https://github.com/jorendorff/crossjig/assets/283361/2d55beab-0fe1-4400-8fc5-0f2d5c62b1c3"> <img width="122" alt="Adjacent pieces with 2px of border between them." src="https://github.com/jorendorff/crossjig/assets/283361/9ca38d7f-100e-482d-ac0e-e0f8f13db6b1">

Also, when a piece has an concave corner (like the two inner corners on a T-shaped piece, for example), there is a 1px square missing where the border isn't drawn through the interior corner as you'd expect.

<img width="105" alt="L-shaped piece with a pixel missing from the border." src="https://github.com/jorendorff/crossjig/assets/283361/433aa810-706f-4aef-9064-be3cd8007e3b">

This PR makes the letters overlap by 1px so that the border between adjacent pieces is only 1px and interior corners look nice.

After: <img width="273" alt="Several adjacent pieces with only 1px of border between them." src="https://github.com/jorendorff/crossjig/assets/283361/d01e5038-f512-4161-ba30-613410cc3814"> <img width="108" alt="Pieces set corner-to-corner; the borders now line up." src="https://github.com/jorendorff/crossjig/assets/283361/c38d6985-36c5-4202-a480-dd3d1d42c9f2">

