### PR TITLE
Prevent reason from disappearing with each drag when all pieces are on the board

### DIFF
--- a/src/logic/gameReducer.js
+++ b/src/logic/gameReducer.js
@@ -206,7 +206,13 @@ function dragStart({
     };
   }
 
-  return updateCompletionState(currentGameState);
+  // Clear `gameIsSolved`, but don't recompute the whole completion state. This prevents
+  // the `gameIsSolvedReason` from disappearing on each drag when all the pieces are
+  // on the board but the puzzle isn't solved yet.
+  return {
+    ...currentGameState,
+    gameIsSolved: false,
+  };
 }
 
 // We let the pointer wander a few pixels before setting dragHasMoved.


### PR DESCRIPTION
Whenever any piece is being dragged, the `gameIsSolvedReason` is _not_ displayed. I accidentally introduced this behavior in #5, but didn't notice until it was merged.

The new behavior is bad because if all pieces are on the board, it'll say "All of the letters must connect", and then every time you drag a piece, the message disappears. Drop the piece and the message reappears. It blinks. It's not wrong, exactly, just annoying.

So this PR tries to change it back. It's a bit of a hack...