### PR TITLE
Don't lint compiled files and don't deploy for changes to lint-related files

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -21,5 +21,6 @@
   "plugins": ["react"],
   "rules": {
     "react/prop-types": "off"
-  }
+  },
+  "ignorePatterns": ["dist/*"]
 }

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,6 +7,11 @@ on:
       - "README.md"
       - "TODO.md"
       - ".github/ISSUE_TEMPLATE/*"
+      - ".eslintrc.json"
+      - ".gitignore"
+      - ".prettierignore"
+      - ".prettierrc.json"
+      - ".stylelintrc.json"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
- Excludes the dist directory, which holds the compiled files, from eslint
- Makes the deployment workflow ignore changes to linter configuration files and the gitignore file