### PR TITLE
Use CSS cursor property to indicate dragging

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -409,6 +409,20 @@ a {
   transform: translate(var(--lift), var(--lift));
 }
 
+.letter,
+#board:not(:empty) {
+  cursor: grab;
+}
+
+#drag-group {
+  cursor: grabbing;
+}
+
+/* Separate rule for graceful degradation -- Firefox doesn't support :has() yet. */
+body:has(#drag-group) {
+  cursor: grabbing;
+}
+
 #result {
   display: flex;
   justify-content: center;


### PR DESCRIPTION
This makes the mouse pointer turn into a hand when it's over a piece, on systems with a mouse. No effect on touch screens.

It's kind of nice that it gives the user an extra hint that the background of the board is draggable too.