### PR TITLE
Let the player use long words in solutions

### DIFF
--- a/src/logic/trie.js
+++ b/src/logic/trie.js
@@ -5,6 +5,7 @@ import {
   commonWordsLen5,
   commonWordsLen6,
   commonWordsLen7,
+  commonWordsLen8plus,
 } from "@skedwards88/word_lists";
 
 export const trie = getTrie(
@@ -14,6 +15,7 @@ export const trie = getTrie(
     ...commonWordsLen5,
     ...commonWordsLen6,
     ...commonWordsLen7,
+    ...commonWordsLen8plus,
   ],
   []
 );


### PR DESCRIPTION
True story: I had solved everything except where to put the last single-letter S piece...

<img width="376" alt="two screenshots of the game: Unknown word DESPAIRS; Unknown word WEEKENDS" src="https://github.com/skedwards88/crossjig/assets/283361/60729816-ea44-4be9-a582-c0a961f2e965">

The game doesn't use words longer than 7 letters in puzzles, but the player should be allowed to use long words in their solution.