### PR TITLE
Don't configure google analytics on localhost

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -7,13 +7,17 @@
       src="https://www.googletagmanager.com/gtag/js?id=G-W4QKC8003K"
     ></script>
     <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag() {
-        dataLayer.push(arguments);
-      }
-      gtag("js", new Date());
+      const host = window.location.hostname;
+      if(host != "localhost")
+      {
+        window.dataLayer = window.dataLayer || [];
+        function gtag() {
+          dataLayer.push(arguments);
+        }
+        gtag("js", new Date());
 
-      gtag("config", "G-W4QKC8003K");
+        gtag("config", "G-W4QKC8003K");
+      }
     </script>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width,initial-scale=1" />


### PR DESCRIPTION
Only configures the google analytics gtag when not on localhost. It looks like the analytics might be skewed due to local development (e.g. views on desktop are higher than views on mobile). This should keep our local development/testing from being recorded in the analytics.