### PR TITLE
Allow solutions to include 2 letter words

### DIFF
--- a/src/logic/trie.js
+++ b/src/logic/trie.js
@@ -1,5 +1,6 @@
 import { getTrie } from "@skedwards88/word_logic";
 import {
+  commonWordsLen2,
   commonWordsLen3,
   commonWordsLen4,
   commonWordsLen5,
@@ -10,6 +11,7 @@ import {
 
 export const trie = getTrie(
   [
+    ...commonWordsLen2,
     ...commonWordsLen3,
     ...commonWordsLen4,
     ...commonWordsLen5,


### PR DESCRIPTION
One player noted that two letter words like as were not recognized as words. This PR allows two letter words in the solution.