### PR TITLE
Make daily challenge more responsive

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -44,6 +44,28 @@ export default function App() {
     gameInit
   );
 
+  const [, setLastOpened] = React.useState(Date.now());
+
+  function handleVisibilityChange() {
+    // If the visibility of the app changes to become visible,
+    // update the state to force the app to re-render.
+    // This is to help the daily challenge refresh if the app has
+    // been open in the background since an earlier challenge.
+    if (!document.hidden) {
+      setLastOpened(Date.now());
+    }
+  }
+
+  React.useEffect(() => {
+    // When the component is mounted, attach the visibility change event listener
+    // (and remove the event listener when the component is unmounted).
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+
+    return () => {
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+    };
+  }, []);
+
   React.useEffect(() => {
     window.addEventListener("beforeinstallprompt", (event) =>
       handleBeforeInstallPrompt(

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -103,7 +103,7 @@ export default function App() {
     case "daily":
       // force reinitialize the daily state if the day has changed
       if (dailyGameState.seed != getDailySeed()) {
-        dailyGameState = gameInit({ isDaily: true, useSaved: false });
+        dailyDispatchGameState({action: "newGame", isDaily: true, useSaved: false});
       }
       return (
         <div className="App" id="crossjig">


### PR DESCRIPTION
Closes https://github.com/skedwards88/crossjig/issues/17

Fixes the bug identified in https://github.com/skedwards88/crossjig/issues/17 by calling the reducer to update the game state instead of calling the init function.

Also adds a visibilitychange event listener and forces the app to rerender when the app becomes visible. This makes the daily challenge refresh when you reopen the app, instead of waiting for user interaction to refresh.