### PR TITLE
Use saved state for non-daily puzzle even if seed differs

### DIFF
--- a/src/logic/gameInit.js
+++ b/src/logic/gameInit.js
@@ -54,7 +54,8 @@ export function gameInit({
 
   if (
     savedState &&
-    savedState.seed === seed &&
+    savedState.seed &&
+    ((isDaily && savedState.seed === seed) || !isDaily) &&
     savedState.pieces &&
     savedState.gridSize &&
     savedState.numLetters &&

--- a/src/logic/gameReducer.js
+++ b/src/logic/gameReducer.js
@@ -483,7 +483,6 @@ function updateCompletionState(gameState) {
 }
 
 export function gameReducer(currentGameState, payload) {
-  console.log(payload);
   if (payload.action === "newGame") {
     return gameInit({ ...payload, seed: undefined, useSaved: false });
   } else if (payload.action === "getHint") {


### PR DESCRIPTION
Changes the init to only force the seed to be the same fore the daily challenge in order to use the saved state. For the non daily challenges, the seed will differ on every init call, so this matching seed requirement is removed.