### PR TITLE
Let the pointer wander more before canceling multi-select

### DIFF
--- a/src/components/Piece.js
+++ b/src/components/Piece.js
@@ -14,16 +14,11 @@ function Letter({
     event.stopPropagation();
     const pointer = { x: event.clientX, y: event.clientY };
     const letterElement = event.currentTarget;
-    const pieceRect = letterElement.parentElement.getBoundingClientRect();
     dispatchGameState({
       action: "dragStart",
       pieceID,
       pointerID: event.pointerId,
       pointer,
-      pointerOffset: {
-        x: pointer.x - pieceRect.left,
-        y: pointer.y - pieceRect.top,
-      },
     });
   };
 

--- a/src/components/Piece.js
+++ b/src/components/Piece.js
@@ -13,7 +13,6 @@ function Letter({
     event.preventDefault();
     event.stopPropagation();
     const pointer = { x: event.clientX, y: event.clientY };
-    const letterElement = event.currentTarget;
     dispatchGameState({
       action: "dragStart",
       pieceID,

--- a/src/logic/gameReducer.js
+++ b/src/logic/gameReducer.js
@@ -132,7 +132,8 @@ function dragStart({
 
   let pointerOffset;
   if (previousDragState && previousDragState.pieceIDs.length == 1) {
-    // Use previous pointerOffset, adjusted for the different group of pieces we have now.
+    // If we were previously just dragging one piece and have now potentially expanded to drag multiple pieces,
+    // use previous pointerOffset, adjusted for the different group of pieces we have now.
     const previousPiece = currentGameState.pieces.filter(
       (piece) => piece.id == previousDragState.pieceIDs[0]
     )[0];

--- a/src/logic/gameReducer.js
+++ b/src/logic/gameReducer.js
@@ -91,7 +91,6 @@ function dragStart({
   isPartOfCurrentDrag,
   pointerID,
   pointer,
-  pointerOffset,
   isShifting,
 }) {
   if (currentGameState.dragState !== undefined) {
@@ -131,27 +130,25 @@ function dragStart({
   }
 
   // Find the top left of the group in client coordinates, to get pointerOffset.
-  if (pointerOffset === undefined) {
-    const rectangles = targets.flatMap((piece) => {
-      const element = document.getElementById(`piece-${piece.id}`);
-      if (!element) {
-        console.warn(
-          `dragStart: element for piece ${piece.id} not found in DOM`
-        );
-        return [];
-      }
-      return [element.getBoundingClientRect()];
-    });
-    if (rectangles.length === 0) {
-      return currentGameState;
+  const rectangles = targets.flatMap((piece) => {
+    const element = document.getElementById(`piece-${piece.id}`);
+    if (!element) {
+      console.warn(
+        `dragStart: element for piece ${piece.id} not found in DOM`
+      );
+      return [];
     }
-    const groupTop = Math.min(...rectangles.map((rect) => rect.top));
-    const groupLeft = Math.min(...rectangles.map((rect) => rect.left));
-    pointerOffset = {
-      x: pointer.x - groupLeft,
-      y: pointer.y - groupTop,
-    };
+    return [element.getBoundingClientRect()];
+  });
+  if (rectangles.length === 0) {
+    return currentGameState;
   }
+  const groupTop = Math.min(...rectangles.map((rect) => rect.top));
+  const groupLeft = Math.min(...rectangles.map((rect) => rect.left));
+  const pointerOffset = {
+    x: pointer.x - groupLeft,
+    y: pointer.y - groupTop,
+  };
 
   currentGameState = {
     ...currentGameState,
@@ -498,13 +495,12 @@ export function gameReducer(currentGameState, payload) {
   } else if (payload.action === "dragStart") {
     // Fired on pointerdown on a piece anywhere.
     // Captures initial `dragState`. `destination` is initialized to where the piece already is.
-    const { pieceID, pointerID, pointer, pointerOffset } = payload;
+    const { pieceID, pointerID, pointer } = payload;
     return dragStart({
       currentGameState,
       isPartOfCurrentDrag: (piece) => piece.id === pieceID,
       pointerID,
       pointer,
-      pointerOffset,
       isShifting: false,
     });
   } else if (payload.action === "dragNeighbors") {
@@ -529,7 +525,6 @@ export function gameReducer(currentGameState, payload) {
       isPartOfCurrentDrag: (piece) => connectedPieceIDs.includes(piece.id),
       pointerID: dragState.pointerID,
       pointer: dragState.pointer,
-      pointerOffset: undefined,
       isShifting: false,
     });
   } else if (payload.action === "dragMove") {
@@ -565,7 +560,6 @@ export function gameReducer(currentGameState, payload) {
       isPartOfCurrentDrag: (piece) => piece.boardTop !== undefined,
       pointerID,
       pointer,
-      pointerOffset: undefined,
       isShifting: true,
     });
   } else if (payload.action === "clearStreakIfNeeded") {

--- a/src/logic/gameReducer.js
+++ b/src/logic/gameReducer.js
@@ -217,7 +217,7 @@ function dragStart({
 
 // We let the pointer wander a few pixels before setting dragHasMoved.
 function hasMoved(start, pointer) {
-  const NOT_FAR = 5.0; // pixels
+  const NOT_FAR = 9.0; // pixels
   return Math.hypot(pointer.x - start.x, pointer.y - start.y) > NOT_FAR;
 }
 


### PR DESCRIPTION
On my phone, I fairly often get more than 5px of wiggle accidentally. 9px works well.

Also fixes an existing bug where `dragNeighbors` didn't correctly adjust the `pointerOffset` for this little swerve.
