### PR TITLE
Accept all original solution words

### DIFF
--- a/src/logic/gameSolvedQ.js
+++ b/src/logic/gameSolvedQ.js
@@ -1,5 +1,6 @@
 import { crosswordValidQ } from "@skedwards88/word_logic";
 import { trie } from "../logic/trie";
+import { getWordsFromPieces } from "./getWordsFromPieces";
 
 function piecesOverlapQ(boardPieces, gridSize) {
   let overlappingPiecesQ = false;
@@ -48,7 +49,13 @@ export function gameSolvedQ(pieces, gridSize) {
     };
   }
 
-  const { gameIsSolved, reason } = crosswordValidQ({ grid: grid, trie: trie });
+  const originalWords = getWordsFromPieces({ pieces, gridSize });
+
+  const { gameIsSolved, reason } = crosswordValidQ({
+    grid: grid,
+    trie: trie,
+    exceptedWords: originalWords,
+  });
 
   return {
     gameIsSolved: gameIsSolved,

--- a/src/logic/getSolutionFromPieces.js
+++ b/src/logic/getSolutionFromPieces.js
@@ -1,0 +1,33 @@
+export function getSolutionFromPieces({ pieces, gridSize }) {
+  if (pieces === undefined) {
+    throw new Error("Pieces must be defined.");
+  }
+
+  if (gridSize === undefined) {
+    throw new Error("Grid size must be defined.");
+  }
+
+  let grid = Array.from({ length: gridSize }, () =>
+    Array.from({ length: gridSize }, () => "")
+  );
+
+  for (const piece of pieces) {
+    const letters = piece.letters;
+    let top = piece.solutionTop;
+    for (let rowIndex = 0; rowIndex < letters.length; rowIndex++) {
+      let left = piece.solutionLeft;
+      for (let colIndex = 0; colIndex < letters[rowIndex].length; colIndex++) {
+        if (letters[rowIndex][colIndex]) {
+          if (grid[top][left] == undefined) {
+            throw new Error("A piece falls outside of the grid boundary.");
+          }
+          grid[top][left] = letters[rowIndex][colIndex];
+        }
+        left += 1;
+      }
+      top += 1;
+    }
+  }
+
+  return grid;
+}

--- a/src/logic/getSolutionFromPieces.test.js
+++ b/src/logic/getSolutionFromPieces.test.js
@@ -1,0 +1,183 @@
+import { getSolutionFromPieces } from "./getSolutionFromPieces";
+
+describe("getSolutionFromPieces", () => {
+  test("it returns a 2D array representing the placement of the pieces in a grid", () => {
+    const pieces = [
+      {
+        letters: [
+          ["", "C", ""],
+          ["L", "A", "Y"],
+          ["", "R", ""],
+        ],
+        solutionTop: 5,
+        solutionLeft: 7,
+      },
+      {
+        letters: [["K"], ["N"], ["O"]],
+        solutionTop: 2,
+        solutionLeft: 10,
+      },
+      { letters: [["N", "S"]], solutionTop: 10, solutionLeft: 9 },
+      { letters: [["E", "A"]], solutionTop: 10, solutionLeft: 6 },
+      { letters: [["B"], ["S"]], solutionTop: 5, solutionLeft: 10 },
+      {
+        letters: [
+          ["I", "", ""],
+          ["V", "", ""],
+          ["E", "Z", "E"],
+        ],
+        solutionTop: 3,
+        solutionLeft: 3,
+      },
+      { letters: [["A"], ["W"]], solutionTop: 3, solutionLeft: 5 },
+      {
+        letters: [
+          ["S", "P", "A"],
+          ["", "R", ""],
+          ["", "E", ""],
+        ],
+        solutionTop: 0,
+        solutionLeft: 0,
+      },
+      {
+        letters: [
+          ["", "", "E"],
+          ["S", "O", "R"],
+        ],
+        solutionTop: 10,
+        solutionLeft: 2,
+      },
+      {
+        letters: [
+          ["", "F", ""],
+          ["", "E", ""],
+          ["B", "R", "E"],
+        ],
+        solutionTop: 3,
+        solutionLeft: 0,
+      },
+      { letters: [["V", "I"]], solutionTop: 11, solutionLeft: 0 },
+      {
+        letters: [
+          ["N", "S"],
+          ["A", ""],
+          ["T", "E"],
+        ],
+        solutionTop: 0,
+        solutionLeft: 3,
+      },
+      {
+        letters: [
+          ["", "N", ""],
+          ["S", "I", "M"],
+          ["", "C", ""],
+        ],
+        solutionTop: 7,
+        solutionLeft: 3,
+      },
+      {
+        letters: [
+          ["", "", "R"],
+          ["", "", "A"],
+          ["L", "L", "S"],
+        ],
+        solutionTop: 0,
+        solutionLeft: 5,
+      },
+      { letters: [["F"]], solutionTop: 1, solutionLeft: 5 },
+      { letters: [["P"], ["Y"]], solutionTop: 3, solutionLeft: 7 },
+      { letters: [["D", "E"]], solutionTop: 6, solutionLeft: 5 },
+      {
+        letters: [
+          ["P", "L", "E"],
+          ["", "", "E"],
+          ["", "", "R"],
+        ],
+        solutionTop: 8,
+        solutionLeft: 6,
+      },
+    ];
+
+    const expectedGrid = [
+      ["S", "P", "A", "N", "S", "", "", "R", "", "", "", ""],
+      ["", "R", "", "A", "", "F", "", "A", "", "", "", ""],
+      ["", "E", "", "T", "E", "L", "L", "S", "", "", "K", ""],
+      ["", "F", "", "I", "", "A", "", "P", "", "", "N", ""],
+      ["", "E", "", "V", "", "W", "", "Y", "", "", "O", ""],
+      ["B", "R", "E", "E", "Z", "E", "", "", "C", "", "B", ""],
+      ["", "", "", "", "", "D", "E", "L", "A", "Y", "S", ""],
+      ["", "", "", "", "N", "", "", "", "R", "", "", ""],
+      ["", "", "", "S", "I", "M", "P", "L", "E", "", "", ""],
+      ["", "", "", "", "C", "", "", "", "E", "", "", ""],
+      ["", "", "", "", "E", "", "E", "A", "R", "N", "S", ""],
+      ["V", "I", "S", "O", "R", "", "", "", "", "", "", ""],
+    ];
+    expect(getSolutionFromPieces({ pieces, gridSize: 12 })).toEqual(
+      expectedGrid
+    );
+  });
+
+  test("any overlapping positions are overwritten", () => {
+    const pieces = [
+      {
+        letters: [
+          ["", "C", ""],
+          ["L", "A", "Y"],
+          ["", "R", ""],
+        ],
+        solutionTop: 0,
+        solutionLeft: 0,
+      },
+      { letters: [["", "T", "O"]], solutionTop: 0, solutionLeft: 0 },
+    ];
+    const expectedGrid = [
+      ["", "T", "O"],
+      ["L", "A", "Y"],
+      ["", "R", ""],
+    ];
+    expect(getSolutionFromPieces({ pieces, gridSize: 3 })).toEqual(
+      expectedGrid
+    );
+  });
+
+  test("an empty array of pieces results in an empty grid", () => {
+    const pieces = [];
+    const expectedGrid = [
+      ["", "", ""],
+      ["", "", ""],
+      ["", "", ""],
+    ];
+    expect(getSolutionFromPieces({ pieces, gridSize: 3 })).toEqual(
+      expectedGrid
+    );
+  });
+
+  test("an error is thrown if a piece does not fit on the grid", () => {
+    const pieces = [
+      {
+        letters: [
+          ["", "C", ""],
+          ["L", "A", "Y"],
+          ["", "R", ""],
+        ],
+        solutionTop: 0,
+        solutionLeft: 0,
+      },
+      { letters: [["", "T", "O"]], solutionTop: 0, solutionLeft: 0 },
+    ];
+
+    expect(() => getSolutionFromPieces({ pieces, gridSize: 2 })).toThrow(
+      "A piece falls outside of the grid boundary."
+    );
+  });
+
+  test("an error is thrown if either input is undefined", () => {
+    expect(() => getSolutionFromPieces({ gridSize: 2 })).toThrow(
+      "Pieces must be defined."
+    );
+
+    expect(() => getSolutionFromPieces({ pieces: [] })).toThrow(
+      "Grid size must be defined."
+    );
+  });
+});

--- a/src/logic/getWordsFromGrid.js
+++ b/src/logic/getWordsFromGrid.js
@@ -23,6 +23,9 @@ function getHorizontalWordsFromGrid(grid) {
 }
 
 export function getWordsFromGrid(grid) {
+  // The simple method of grid transposition used in this function
+  // relies on an equal number of rows and columns,
+  // so throw errors if that isn't the case
   if (grid.length != grid[0]?.length) {
     throw new Error(
       `The number of columns and number of rows in the grid must be equal.`

--- a/src/logic/getWordsFromGrid.js
+++ b/src/logic/getWordsFromGrid.js
@@ -1,0 +1,43 @@
+function getHorizontalWordsFromGrid(grid) {
+  let words = [];
+
+  for (const row of grid) {
+    let word = "";
+    for (const letter of row) {
+      if (letter != "") {
+        word += letter;
+      } else {
+        if (word.length > 1) {
+          words.push(word);
+        }
+        word = "";
+      }
+    }
+    // Also push the word if we reach the end of the row
+    if (word.length > 1) {
+      words.push(word);
+    }
+  }
+
+  return words;
+}
+
+export function getWordsFromGrid(grid) {
+  if (grid.length != grid[0]?.length) {
+    throw new Error(
+      `The number of columns and number of rows in the grid must be equal.`
+    );
+  }
+
+  const numColumnsPerRow = grid.map((row) => row.length);
+  if (Math.min(...numColumnsPerRow) != Math.max(...numColumnsPerRow)) {
+    throw new Error(`All of the rows in the grid must have the same length.`);
+  }
+
+  const transposedGrid = grid.map((_, index) => grid.map((row) => row[index]));
+
+  return [
+    ...getHorizontalWordsFromGrid(grid),
+    ...getHorizontalWordsFromGrid(transposedGrid),
+  ];
+}

--- a/src/logic/getWordsFromGrid.test.js
+++ b/src/logic/getWordsFromGrid.test.js
@@ -1,0 +1,82 @@
+import { getWordsFromGrid } from "./getWordsFromGrid";
+
+describe("getWordsFromGrid", () => {
+  test("it returns the horizontal and vertical sequences of 2 or more characters from a 2D array of characters", () => {
+    const grid = [
+      ["A", "B", "", "", ""],
+      ["E", "", "", "F", "I"],
+      ["G", "H", "I", "M", ""],
+      ["J", "K", "", "Q", "W"],
+      ["W", "X", "", "", ""],
+    ];
+    const expectedWords = [
+      "AB",
+      "FI",
+      "GHIM",
+      "JK",
+      "QW",
+      "WX",
+      "AEGJW",
+      "HKX",
+      "FMQ",
+    ];
+    expect(getWordsFromGrid(grid)).toEqual(expectedWords);
+  });
+
+  test("it returns an empty array when there are no characters", () => {
+    const grid = [
+      ["", "", ""],
+      ["", "", ""],
+      ["", "", ""],
+    ];
+    expect(getWordsFromGrid(grid)).toEqual([]);
+  });
+
+  test("it returns an empty array when there are no sequences longer than 1 character", () => {
+    const grid = [
+      ["A", "", "C"],
+      ["", "B", ""],
+      ["D", "", ""],
+    ];
+    expect(getWordsFromGrid(grid)).toEqual([]);
+  });
+
+  test("it works with characters at the borders of the grid", () => {
+    const grid = [
+      ["O", "N", "E"],
+      ["U", "", "X"],
+      ["T", "W", "O"],
+    ];
+    const expectedWords = ["ONE", "TWO", "OUT", "EXO"];
+    expect(getWordsFromGrid(grid)).toEqual(expectedWords);
+  });
+
+  test("it rejects grids that are wider than tall", () => {
+    const grid = [["W", "I", "D", "E"]];
+    expect(() => getWordsFromGrid(grid)).toThrow(
+      "The number of columns and number of rows in the grid must be equal."
+    );
+  });
+
+  test("it rejects grids that are taller than wide, including empty grids", () => {
+    const grid = [["T"], ["A"], ["L"], ["L"]];
+    expect(() => getWordsFromGrid(grid)).toThrow(
+      "The number of columns and number of rows in the grid must be equal."
+    );
+
+    expect(() => getWordsFromGrid([])).toThrow(
+      "The number of columns and number of rows in the grid must be equal."
+    );
+  });
+
+  test("it rejects grids have uneven row lengths", () => {
+    const grid = [
+      ["A", "", "C"],
+      ["", "B", "", "E"],
+      ["D", "", ""],
+    ];
+    expect(() => getWordsFromGrid(grid)).toThrow(
+      "All of the rows in the grid must have the same length."
+    );
+  });
+});

--- a/src/logic/getWordsFromPieces.js
+++ b/src/logic/getWordsFromPieces.js
@@ -1,0 +1,10 @@
+import { getSolutionFromPieces } from "./getSolutionFromPieces";
+import { getWordsFromGrid } from "./getWordsFromGrid";
+
+export function getWordsFromPieces({ pieces, gridSize }) {
+  const grid = getSolutionFromPieces({ pieces, gridSize });
+
+  const words = getWordsFromGrid(grid);
+
+  return words;
+}


### PR DESCRIPTION
As pointed out in https://github.com/skedwards88/crossjig/pull/22, a puzzle could be generated and then the word list could be updated to exclude one of the words in the puzzle before the puzzle was solved. This PR counts all of the original words in the puzzle as valid, even if they are no longer in the word list.

https://github.com/skedwards88/word_logic/pull/2 makes the corresponding changes to the core crosswordValidQ function. The PRs can merge in any order.